### PR TITLE
2018-06-22-02

### DIFF
--- a/_i18n/en/_posts/pagador/2017-07-26-braspag-pagador.md
+++ b/_i18n/en/_posts/pagador/2017-07-26-braspag-pagador.md
@@ -1567,7 +1567,7 @@ The Cybersource's Fraud Prevention requires the "FraudAnalysis" node filled.
      "FraudAnalysis":{
        "Sequence":"AnalyseFirst",
        "SequenceCriteria":"Always",
-       "Provider": "Cybersource",	   
+       "Provider": "Cybersource", 
        "CaptureOnLowRisk":false,
        "VoidOnHighRisk":false,
        "TotalOrderAmount": 10000,       
@@ -1690,10 +1690,10 @@ curl
      "FraudAnalysis":{
        "Sequence":"AnalyseFirst",
        "SequenceCriteria":"Always",
-       "Provider": "Cybersource",	   
+       "Provider": "Cybersource",
        "CaptureOnLowRisk":false,
        "VoidOnHighRisk":false,
-       "TotalOrderAmount": 10000,	   
+       "TotalOrderAmount": 10000,
        "FingerPrintId":"074c1ee676ed4998ab66491013c565e2",    
       "Browser":{
        "CookiesAccepted":false,


### PR DESCRIPTION
Tentativa 2
. Colocar o Provider do Antifraude como obrigatório no manual, pois sem informar, ele vai pro legado. O manual deverá incentivar a integração no gateway de antifraude e não legado.

. Colocar a menção sobre o campo TotalOrderAmount na integração com o Antifraude Cyber, que hoje de fato só menciona para Red no manual

. Adequar os valores possíveis para FraudAnalysis.Status (
•    Unknown = 0
•    Accept = 1
•    Reject = 2
•    Review = 3
•    Aborted = 4
•    Error = 5)