### PR TITLE
Update 2018-09-09-env3ds.md

### DIFF
--- a/_i18n/pt/_posts/env3ds/2018-09-09-env3ds.md
+++ b/_i18n/pt/_posts/env3ds/2018-09-09-env3ds.md
@@ -195,7 +195,7 @@ Uma vez que a classe é mapeada em determinado campo, o script é capaz de recup
 | bpmpi_paymentmethod | Tipo do cartão a ser autenticado. No caso do cartão múltiplo, deverá especificar um dos tipos, Credit ou Debit | Credit – Cartão de Crédito<br>Debit – Cartão de Débito | Sim | Sim |
 | bpmpi_cardnumber | Número do Cartão | Numérico [até 19 posições] | Sim | Sim |
 | bpmpi_cardexpirationmonth | Mês do vencimento do cartão | Numérico [2 posições] | Sim | Sim |
-| bpmpi_cardexpirationyear | Ano do vencimento do cartão | Numérico [2 posições] | Sim | Sim |
+| bpmpi_cardexpirationyear | Ano do vencimento do cartão | Numérico [4 posições] | Sim | Sim |
 | bpmpi_cardalias | Alias do cartão | Alphanumérico [até 128 posições] | Não | Sim |
 | bpmpi_default_card | Indica se é um cartão padrão do cliente na loja | Booleano<br>true - sim<br>false - não | Não | Sim |
 
@@ -209,34 +209,39 @@ Uma vez que a classe é mapeada em determinado campo, o script é capaz de recup
 | bpmpi_order_cardattemptslast24hours | Quantidade de transações com o mesmo cartão nas últimas 24h | Numérico [até 3 posições] | Não | Sim |
 | bpmpi_order_marketingoptin | Indica se o comprador aceitou receber ofertas de marketing | Booleano<br>true – sim<br>false – não  | Não | Sim |
 | bpmpi_order_marketingsource | Identifica a origem da campanha de marketing | Alfanumérico [até 40 posições] | Não | Sim |
+| bpmpi_transaction_mode | Identifica o canal que originou a transação | M: MOTO<br>R: Varejo<br>S: E-Commerce<br>P: Mobile<br>T: Tablet | Não | Sim |
+| bpmpi_merchant_url | Endereço do site do estabelcimento | Alphanumérico [100] Exemplo: http://www.exemplo.com.br | Não | Sim |
 
 | **Dados específicos para cartões Gift Card (pré-pago)** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
-| bpmpi_giftcard_amount | O total do valor da compra para cartões-presente pré-pagos em valor arredondado | Numérico [até 15 posições],<br>exemplo: R$ 125,54 = 125 | Não | Sim |
+| bpmpi_giftcard_amount | O total do valor da compra para cartões-presente pré-pagos em valor arredondado | Numérico [até 15 posições],<br>exemplo: R$ 125,54 = 12554 | Não | Sim |
 | bpmpi_giftcard_currency | Código da moeda da transação paga com cartão do tipo pré-pago | Fixo &quot;BRL&quot; | Não | Sim |
 
 | **Dados de endereço de cobrança** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
-| bpmpi_billTo_Name| Nome do contato do endereço de cobrança | Alfanumérico [até 120] | Não | Sim |
-| bpmpi_billTo_phoneNumber | Telefone de contato do endereço de cobrança | Alfanumérico [até 15 posições], no formato: 5511999999999 | Não | Sim |
+| bpmpi_billto_customerid | Identifica o CPF/CNPJ do comprador | Numérico [11 a 14 posições]<br>99999999999999 | Não | Sim |
+| bpmpi_billto_contactname| Nome do contato do endereço de cobrança | Alfanumérico [até 120] | Não | Sim |
+| bpmpi_billTo_phoneNumber | Telefone de contato do endereço de cobrança | Numérico [até 15 posições], no formato: 5511999999999 | Não | Sim |
 | bpmpi_billTo_email | E-mail do contato do endereço de cobrança | Alfanumérico [até 255], no formato [nome@exemplo.com](mailto:nome@exemplo.com) | Não | Sim |
 | bpmpi_billTo_street1 | Logradouro e Número do endereço de cobrança | Alfanumérico [até 60] | Não | Sim |
 | bpmpi_billTo_street2 | Complemento e bairro do endereço de cobrança | Alfanumérico [até 60] | Não | Sim |
 | bpmpi_billTo_city | Cidade do endereço de cobrança | Alfanumérico [até 50] | Não | Sim |
 | bpmpi_billTo_state | Sigla do estado do endereço de cobrança | Texto [2 posições] | Não | Sim |
-| bpmpi_billto_zipcode | CEP do endereço de cobrança | Alfanumérico [até 10 posições], no formato: 99999999 | Não | Sim |
+| bpmpi_billto_zipcode | CEP do endereço de cobrança | Alfanumérico [até 8 posições], no formato: 99999999 | Não | Sim |
+| bpmpi_billto_country | País do endereço de cobrança | Texto [2 posições] Ex. BR | Não | Sim |
 
 | **Dados de endereço de entrega** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
 | bpmpi_shipto_sameasbillto | Indica se utiliza o mesmo endereço fornecido para endereço de cobrança | Booleano<br>true<br>false | Não | Sim |
-| bpmpi_shipTo_name | Nome do contato do endereço de entrega | Alfanumérico [até 60] | Não | Sim |
-| bpmpi_shipTo_phoneNumber | Telefone de contato do endereço de entrega | Alfanumérico [até 15 posições], no formato: 5511999999999 | Não | Sim |
+| bpmpi_shipto_addressee | Nome do contato do endereço de entrega | Alfanumérico [até 60] | Não | Sim |
+| bpmpi_shipTo_phoneNumber | Telefone de contato do endereço de entrega | Numérico [até 15 posições], no formato: 5511999999999 | Não | Sim |
 | bpmpi_shipTo_email | E-mail do contato do endereço de entrega | Alfanumérico [até 255], no formato [nome@exemplo.com](mailto:nome@exemplo.com) | Não | Sim |
 | bpmpi_shipTo_street1 | Logradouro e Número do endereço de entrega | Alfanumérico [até 60] | Não | Sim |
 | bpmpi_shipTo_street2 | Complemento e bairro do endereço de entrega | Alfanumérico [até 60] | Não | Sim |
 | bpmpi_shipTo_city | Cidade do endereço de entrega | Alfanumérico [até 50] | Não | Sim |
 | bpmpi_shipTo_state | Sigla do estado do endereço de entrega | Texto [2 posições] | Não | Sim |
-| bpmpi_shipto_zipcode | CEP do endereço de entrega | Alfanumérico [até 10 posições], no formato: 99999999 | Não | Sim |
+| bpmpi_shipto_zipcode | CEP do endereço de entrega | Alfanumérico [até 8 posições], no formato: 99999999 | Não | Sim |
+| bpmpi_shipto_country | País do endereço de cobrança | Texto [2 posições] Ex. BR | Não | Sim |
 | bpmpi_shipTo_shippingMethod | Tipo do método de envio | lowcost: envio econômico<br>sameday: envio no mesmo dia<br>oneday: envio no dia seguinte<br>twoday: envio em dois dias<br>threeday: envio em três dias<br>pickup: retirada na loja<br>other: outrosnone: não há envio | Não | Sim |
 | bpmpi_shipto_firstusagedate | Indica a data de quando houve a primeira utilização do endereço de entrega | Texto<br>AAAA-MM-DD – data da criação  | Não | Sim |
 
@@ -256,7 +261,7 @@ Uma vez que a classe é mapeada em determinado campo, o script é capaz de recup
 | bpmpi_useraccount_passwordchangeddate | Indica a data de quando houve a alteração de senha da conta do comprador | Texto<br>AAAA-MM-DD – data da última alteração de senha  | Não | Sim |
 | bpmpi_useraccount_authenticationmethod | Método de autenticação do comprador na loja | 01- Não houve autenticação<br>02- Login da própria loja<br>03- Login com ID federado<br>04- Login com autenticador FIDO | Não | Sim |
 | bpmpi_useraccount_authenticationprotocol | Dado que representa o protocolo de login efetuado na loja | Alfanumérico [até 2048 posições] | Não | Sim |
-| bpmpi_useraccount_authenticationtimestamp | A data e hora que o login foi efetuado na loja | Numérico [12 posições]<br>AAAAMMDDHHMM | Não | Sim |
+| bpmpi_useraccount_authenticationtimestamp | A data e hora que o login foi efetuado na loja | Texto [19 posições] YYYY-MM-ddTHH:mm:SS | Não | Sim |
 
 | **Dados do dispositivo utilizado para compra** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
@@ -270,8 +275,8 @@ Uma vez que a classe é mapeada em determinado campo, o script é capaz de recup
 | bpmpi_airline_travelleg_#_departuredate | Data de partida | Texto<br>AAAA-MM-DD | Não | Sim |
 | bpmpi_airline_travelleg_#_origin | Código IATA do aeroporto de origem | Alfanumérico [5 posições] | Não | Sim |
 | bpmpi_airline_travelleg_#_destination | Código IATA do aeroporto de destino | Alfanumérico [5 posições] | Não | Sim |
-| bpmpi_airline_passenger_#_name| Primeiro nome do passageiro | Alfanumérico [até 60 posições] | Não | Sim |
-| bpmpi_airline_passenger_#_ticketprice | O valor da passagem em centavos  Numérico [até 15 posições],<br>exemplo: R$ 125,54 = 125 | Não | Sim |
+| bpmpi_airline_passenger_#_name| Nome do passageiro | Alfanumérico [até 60 posições] | Não | Sim |
+| bpmpi_airline_passenger_#_ticketprice | O valor da passagem em centavos  Numérico [até 15 posições],<br>exemplo: R$ 125,54 = 12554 | Não | Sim |
 | bpmpi_airline_numberofpassengers | Número de passageiros | Numérico [3 posições] | Não | Sim |
 | bpmpi_airline_billto_passportcountry | Código do país que emitiu o passaporte (ISO Standard Country Codes) | Texto [2 posições] | Não | Sim |
 | bpmpi_airline_billto_passportnumber | Número do passaporte | Alfanumérico [40 posições] | Não | Sim |
@@ -327,7 +332,7 @@ Veja exemplo abaixo, descrito o envio dos dados de autenticação da requisiçã
        "Xid":"Uk5ZanBHcWw2RjRCbEN5dGtiMTB=",
        "Eci":"5",
        "Version":"2",
-       "RefereceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
+       "ReferenceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
      }
    }
 }
@@ -366,7 +371,7 @@ curl
        "Xid":"Uk5ZanBHcWw2RjRCbEN5dGtiMTB=",
        "Eci":"5",
        "Version":"2",
-       "RefereceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
+       "ReferenceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
      }
    }
 }


### PR DESCRIPTION
INCLUSÕES

•	"bpmpi_transaction_mode" (depois do bpmpi_order_marketingsource), - Identifica o canal que originou a transação.  Identifies the channel from which the transaction originates. M: MOTO<br>R: Varejo<br>S: E-Commerce<br>P: Mobile<br>T: Tablet 
•	"bpmpi_merchant_url" (depois do bpmpi_transaction_mode), - Endereço do site do estabelcimento.  Alphanumérico [100] Exemplo: http://www.exemplo.com.br | Address of your company’s web site, for example, http://www.example.com.
•	"bpmpi_merchant_newcustomer", - Identifica se um comprador novo na loja. Sim=true Não=false Indicates whether the consumer is a new or existing customer with the merchant
•	"bpmpi_billto_customerid", - Identifica o CPF/CNPJ do comprador. Identifies the CPF/CNPJ of customer.
•	"bpmpi_billto_country", -  País do endereço de cobrança. Ex. BR. Billing country for the account. 
•	"bpmpi_shipto_country" - País do endereço de entrega. Ex. BR. Shippíng country for the account. 

ALTERAÇÕES

•	"bpmpi_billto_name" para "bpmpi_billto_contactname"
•	bpmpi_useraccount_authenticationtimestamp - Numérico [12 posições] AAAAMMDDHHMM para Texto [19 posições] YYYY-MM-ddTHH:mm:SS
•	bpmpi_shipTo_name para bpmpi_shipto_addressee
•	bpmpi_cardexpirationyear Numérico [2 posições] para Numérico [4 posições]
•	bpmpi_billto_zipcode Alfanumérico [até 8 posições]
•	bpmpi_shipto_zipcode Alfanumérico [até 8 posições]
•	bpmpi_billTo_phoneNumber Alfanumérico para Numérico
•	bpmpi_shipTo_phoneNumber Alfanumérico para Numérico
•	bpmpi_airline_passenger_#_ticketprice exemplo: "R$ 125,54 = 125" para exemplo: "R$ 125,54 = 12554"
•	pmpi_giftcard_amount "R$ 125,54 = 125" para exemplo: "R$ 125,54 = 12554" bpmpi_giftcard_amount 
•	bpmpi_airline_passenger_#_name "Primeiro nome do passageiro" para "Nome do passageiro"
•	No código JSON refereceId para referenceId