### PR TITLE
Corrige valores na documentação de split

### DIFF
--- a/_i18n/pt/_posts/splitdepagamentos/2020-09-04-split-de-pagamentos---cielo-e-commerce.md
+++ b/_i18n/pt/_posts/splitdepagamentos/2020-09-04-split-de-pagamentos---cielo-e-commerce.md
@@ -1069,7 +1069,7 @@ Transação no valor de **R$100,00** com o nó contendo as regras de divisão.
       "splitpayments":[  
          {  
             "subordinatemerchantid":"f2d6eb34-2c6b-4948-8fff-51facdd2a28f",
-            "amount":5000,
+            "amount":6000,
             "fares":{  
                "mdr":5,
                "fee":30
@@ -1077,7 +1077,7 @@ Transação no valor de **R$100,00** com o nó contendo as regras de divisão.
          },
          {  
             "subordinatemerchantid":"9140ca78-3955-44a5-bd44-793370afef94",
-            "amount":5000,
+            "amount":4000,
             "fares":{  
                "mdr":4,
                "fee":15


### PR DESCRIPTION
Os valores da request de split do "exemplo 2) Transação no valor de R$100,00 com o nó contendo as regras de divisão."

Estão incoerentes com a documentação, acredito que o correto seria 6000 e 4000 respectivamente

