### PR TITLE
Fix typo in example credentials for emv3ds

### DIFF
--- a/_i18n/pt/_posts/emv3ds/2018-09-09-emv3ds.md
+++ b/_i18n/pt/_posts/emv3ds/2018-09-09-emv3ds.md
@@ -135,7 +135,7 @@ A integração do script do protocolo de autenticação é composta pelas seguin
 
 Obtenha o valor do *Authorization* concatenando o valor do "ClientID", sinal de dois-pontos (":") e "ClientSecret".
 
-Ex: **dba3a8db-fa54-40e0-8bab-7bfb9b6f2e2e:D/ilRsfoqHlSUChwAMnlyKdDNd7FMsM7cU/vo02REag**
+Ex: **dba3a8db-fa54-40e0-8bab-7bfb9b6f2e2e:D/ilRsfoqHlSUChwAMnlyKdDNd7FMsM7cU/vo02REag=**
 
 Em seguida, codifique o resultado na base 64. Esse código alfanumérico será utilizado na requisição do access token:
 


### PR DESCRIPTION
Section "1. Obtaining the OAuth2 AccessToken" in emv3ds provides example sandbox credentials for testing purposes. However, one place where credentials are appearing is missing the last character to be correct.

Credentials in [Line 138](https://github.com/Braspag/braspag.github.io/blob/docs/_i18n/pt/_posts/emv3ds/2018-09-09-emv3ds.md?plain=1#L138) should match [Line 144](https://github.com/Braspag/braspag.github.io/blob/docs/_i18n/pt/_posts/emv3ds/2018-09-09-emv3ds.md?plain=1#L144).