### PR TITLE
fix: correção do exemplo para venda com cartão de débito

### DIFF
--- a/_i18n/en/_posts/pagador/2017-07-27-braspag-pagador.md
+++ b/_i18n/en/_posts/pagador/2017-07-27-braspag-pagador.md
@@ -648,6 +648,7 @@ See below the representation of a standard **transactional flow** in the creatio
       }
    },
    "Payment":{
+      "Type":"DebitCard",
       "DebitCard":{
          "CardNumber":"************1106",
          "Holder":"NOME DO TITULAR DO CARTÃO",
@@ -670,7 +671,8 @@ See below the representation of a standard **transactional flow** in the creatio
          {  
             "Name":"NomeDoCampo",
             "Value":"ValorDoCampo"
-]}
+         }
+      ]}
       "InitiatedTransactionIndicator": {
           "Category": "C1",
           "Subcategory": "Standingorder"
@@ -716,6 +718,7 @@ See below the representation of a standard **transactional flow** in the creatio
       }
    },
    "Payment":{
+      "Type":"DebitCard"
       "DebitCard":{
          "CardNumber":"************1106",
          "Holder":"NOME DO TITULAR DO CARTÃO",
@@ -738,6 +741,7 @@ See below the representation of a standard **transactional flow** in the creatio
          {  
             "Name":"NomeDoCampo",
             "Value":"ValorDoCampo"
+         }
       ]},
       "InitiatedTransactionIndicator": {
           "Category": "C1",

--- a/_i18n/pt/_posts/pagador/2017-07-27-braspag-pagador.md
+++ b/_i18n/pt/_posts/pagador/2017-07-27-braspag-pagador.md
@@ -647,6 +647,7 @@ Veja abaixo a representação de um **fluxo transacional** padrão na criação 
       }
    },
    "Payment":{
+      "Type":"DebitCard",
       "DebitCard":{
          "CardNumber":"************1106",
          "Holder":"NOME DO TITULAR DO CARTÃO",
@@ -664,7 +665,8 @@ Veja abaixo a representação de um **fluxo transacional** padrão na criação 
          "Xid":"Uk5ZanBHcWw2RjRCbEN5dGtiMTB=",
          "Eci":"5",
          "Version":"2",
-         "ReferenceId":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"      },
+         "ReferenceId":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
+         },
       "InitiatedTransactionIndicator": {
             "Category": "C1",
             "Subcategory": "Standingorder"
@@ -673,6 +675,7 @@ Veja abaixo a representação de um **fluxo transacional** padrão na criação 
          {  
             "Name":"NomeDoCampo",
             "Value":"ValorDoCampo"
+         }
       ]
    }
 }
@@ -716,6 +719,7 @@ Veja abaixo a representação de um **fluxo transacional** padrão na criação 
       }
    },
    "Payment":{
+      "Type":"DebitCard",
       "DebitCard":{
          "CardNumber":"************1106",
          "Holder":"NOME DO TITULAR DO CARTÃO",
@@ -742,6 +746,7 @@ Veja abaixo a representação de um **fluxo transacional** padrão na criação 
          {  
             "Name":"NomeDoCampo",
             "Value":"ValorDoCampo"
+         }
       ]
    }
 }


### PR DESCRIPTION
Correção do exemplo de compra com cartão de débito que faltava uma chave "}" e também a falta do tipo do cartão, "Type":"DebitCard".